### PR TITLE
fix: backup and restore scripts

### DIFF
--- a/scripts/dump-elasticache-to-s3.sh
+++ b/scripts/dump-elasticache-to-s3.sh
@@ -60,6 +60,8 @@ handle_exit() {
 trap 'handle_exit $?' EXIT
 trap 'handle_error $?' ERR
 
+# https://stackoverflow.com/a/46577479/5371505
+export AWS_DEFAULT_REGION="us-east-1"
 cache_cluster_id="test-ch-cluster-001"
 current_time="$(date +"%Y-%m-%d-%H-%M-%S")";
 file_name="${cache_cluster_id}-${current_time}";

--- a/scripts/restore-elasticache-to-docker.sh
+++ b/scripts/restore-elasticache-to-docker.sh
@@ -66,6 +66,8 @@ handle_exit() {
 trap 'handle_exit $?' EXIT
 trap 'handle_error $?' ERR
 
+# https://stackoverflow.com/a/46577479/5371505
+export AWS_DEFAULT_REGION="us-east-1"
 bucket='test-ch-backups-elasticache'
 container_name="my_redis_container"
 dump_file_directory="$HOME"


### PR DESCRIPTION
# Description

Fix backup and restore scripts by adding an export for AWS_DEFAULT_REGION and set it to us-east-1

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] My code follows the style guidelines of this project
- [x] I've run the linter locally.
- [x] I've run the project locally using development environment.
